### PR TITLE
Avoid crash for invalid ID on Android

### DIFF
--- a/src/android/notification/Manager.java
+++ b/src/android/notification/Manager.java
@@ -194,7 +194,9 @@ public class Manager {
         ArrayList<Integer> ids = new ArrayList<Integer>();
 
         for (String key : keys) {
-            ids.add(Integer.parseInt(key));
+            try {
+                ids.add(Integer.parseInt(key));
+            } catch (NumberFormatException ignore) {}
         }
 
         return ids;


### PR DESCRIPTION
Avoid crashing when bulk querying notifications with an ID that is not a valid Integer

It is caught in other places - see options.getIdAsInt

Crash report

java.lang.NumberFormatException: Invalid int: "1426188472873"
at java.lang.Integer.invalidInt(Integer.java:137)
at java.lang.Integer.parse(Integer.java:377)
at java.lang.Integer.parseInt(Integer.java:365)
at java.lang.Integer.parseInt(Integer.java:331)
at de.appplant.cordova.plugin.notification.Manager.getIds(Manager.java:197)
at de.appplant.cordova.plugin.notification.Manager.getAll(Manager.java:246)
at de.appplant.cordova.plugin.notification.Manager.cancelAll(Manager.java:180)
at de.appplant.cordova.plugin.localnotification.LocalNotification.cancelAll(LocalNotification.java:251)
at de.appplant.cordova.plugin.localnotification.LocalNotification.access$300(LocalNotification.java:48)
at de.appplant.cordova.plugin.localnotification.LocalNotification$1.run(LocalNotification.java:148)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
at java.lang.Thread.run(Thread.java:841)